### PR TITLE
Add ability to configure StatsD hostname/port via environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ $ gem install passenger_datadog
 $ passenger-datadog [start|stop|restart|status]
 ```
 
+#### Configuring Datadog hostname/port
+
+```
+$ STATSD_HOSTNAME=dd-agent.local STATSD_PORT=8125 passenger-datadog [start|stop|restart|status]
+```
+
+
 ### Help
 ```
 $ passenger-datadog

--- a/lib/passenger_datadog.rb
+++ b/lib/passenger_datadog.rb
@@ -13,7 +13,11 @@ class PassengerDatadog
       status = `passenger-status --show=xml`
       return if status.empty?
 
-      statsd = Statsd.new
+      if ENV.has_key?("STATSD_HOSTNAME") && ENV.has_key?("STATSD_PORT")
+        statsd = Statsd.new ENV["STATSD_HOSTNAME"], ENV["STATSD_PORT"]
+      else
+        statsd = Statsd.new
+      end
 
       statsd.batch do |s|
         # Good job Passenger 4.0.10. Return non xml in your xml output.


### PR DESCRIPTION
Super simple patch to allow dd-agent/statsd hostname to be set via the environment. Running passenger-datadog in a container environment and dd-agent is running as a separate container.