### PR TITLE
Support for multiple supergroups and refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,4 +34,4 @@ Naming/FileName:
 # Configuration parameters: Exclude.
 Style/Documentation:
   Exclude:
-    - 'lib/passenger_datadog.rb'
+    - 'lib/**/*'

--- a/bin/passenger-datadog
+++ b/bin/passenger-datadog
@@ -7,7 +7,7 @@ require 'passenger_datadog'
 
 Daemons.run_proc('passenger-datadog', dir_mode: :system) do
   loop do
-    PassengerDatadog.run
+    PassengerDatadog.new.run
     sleep(30)
   end
 end

--- a/lib/parsers/base.rb
+++ b/lib/parsers/base.rb
@@ -1,0 +1,31 @@
+module Parsers
+  class Base
+    PREFIX = 'passenger'.freeze
+
+    attr_reader :batch, :xml, :prefix, :tags
+
+    def initialize(batch, xml, prefix: nil, tags: nil)
+      @batch = batch
+      @xml = xml
+      @prefix = prefix
+      @tags = tags
+    end
+
+    protected
+
+    def gauge(xml_key, key)
+      value = xml.xpath(xml_key).text
+      return if value.empty?
+
+      if tags
+        batch.gauge(key_for(key), value, tags: tags)
+      else
+        batch.gauge(key_for(key), value)
+      end
+    end
+
+    def key_for(key)
+      [PREFIX, prefix, key].compact.join(".")
+    end
+  end
+end

--- a/lib/parsers/base.rb
+++ b/lib/parsers/base.rb
@@ -25,7 +25,7 @@ module Parsers
     end
 
     def key_for(key)
-      [PREFIX, prefix, key].compact.join(".")
+      [PREFIX, prefix, key].compact.join('.')
     end
   end
 end

--- a/lib/parsers/group.rb
+++ b/lib/parsers/group.rb
@@ -1,0 +1,17 @@
+module Parsers
+  class Group < Base
+    STATS = %w[
+      capacity_used
+      processes_being_spawned
+      enabled_process_count
+      disabling_process_count
+      disabled_process_count
+    ].freeze
+
+    def run
+      STATS.each do |key|
+        gauge(key, key)
+      end
+    end
+  end
+end

--- a/lib/parsers/group.rb
+++ b/lib/parsers/group.rb
@@ -2,6 +2,8 @@ module Parsers
   class Group < Base
     STATS = %w[
       capacity_used
+      get_wait_list_size
+      disable_wait_list_size
       processes_being_spawned
       enabled_process_count
       disabling_process_count

--- a/lib/parsers/process.rb
+++ b/lib/parsers/process.rb
@@ -1,0 +1,23 @@
+module Parsers
+  class Process < Base
+    STATS = %w[
+      processed
+      sessions
+      busyness
+      concurrency
+      cpu
+      rss
+      private_dirty
+      pss
+      swap
+      real_memory
+      vmsize
+    ].freeze
+
+    def run
+      STATS.each do |key|
+        gauge(key, key)
+      end
+    end
+  end
+end

--- a/lib/parsers/root.rb
+++ b/lib/parsers/root.rb
@@ -1,0 +1,15 @@
+module Parsers
+  class Root < Base
+    STATS = {
+      'process_count' => 'pool.used',
+      'max' => 'pool.max',
+      'get_wait_list_size' => 'request_queue'
+    }.freeze
+
+    def run
+      STATS.each do |xml_key, key|
+        gauge(xml_key, key)
+      end
+    end
+  end
+end

--- a/lib/passenger_datadog.rb
+++ b/lib/passenger_datadog.rb
@@ -19,23 +19,28 @@ class PassengerDatadog
     statsd = Datadog::Statsd.new
     parsed = Nokogiri::XML(status)
 
-    statsd.batch do |s|
-      Parsers::Root.new(s, parsed.xpath('//info')).run
-
-      parsed.xpath('//supergroups/supergroup').each do |supergroup|
-        prefix = normalize_prefix(supergroup.xpath('name').text)
-        Parsers::Group.new(s, supergroup.xpath('group'), prefix: prefix).run
-
-        supergroup.xpath('group/processes/process').each_with_index do |process, index|
-          Parsers::Process.new(s, process, prefix: prefix, tags: ["passenger-process:#{index}"]).run
-        end
-      end
+    statsd.batch do |batch|
+      run_in_batch(batch, parsed)
     end
   end
 
   private
 
+  def run_in_batch(batch, parsed)
+    Parsers::Root.new(batch, parsed.xpath('//info')).run
+
+    multiple_supergroups = parsed.xpath('//supergroups/supergroup').count > 1
+    parsed.xpath('//supergroups/supergroup').each do |supergroup|
+      prefix = multiple_supergroups ? normalize_prefix(supergroup.xpath('name').text) : nil
+      Parsers::Group.new(batch, supergroup.xpath('group'), prefix: prefix).run
+
+      supergroup.xpath('group/processes/process').each_with_index do |process, index|
+        Parsers::Process.new(batch, process, prefix: prefix, tags: ["passenger-process:#{index}"]).run
+      end
+    end
+  end
+
   def normalize_prefix(prefix)
-    prefix.gsub(/(-|\s)/, "_").gsub(/(\W|\d)/i, "")
+    prefix.gsub(/(-|\s)/, '_').gsub(/(\W|\d)/i, '')
   end
 end

--- a/lib/passenger_datadog.rb
+++ b/lib/passenger_datadog.rb
@@ -3,49 +3,39 @@
 require 'nokogiri'
 require 'datadog/statsd'
 
+require 'parsers/base'
+require 'parsers/root'
+require 'parsers/group'
+require 'parsers/process'
+
 class PassengerDatadog
-  GROUP_STATS = %w[capacity_used processes_being_spawned enabled_process_count
-                   disabling_process_count disabled_process_count].freeze
-  PROCESS_STATS = %w[processed sessions busyness concurrency cpu rss
-                     private_dirty pss swap real_memory vmsize].freeze
+  def run
+    status = `passenger-status --show=xml`
+    return if status.empty?
 
-  class << self
-    def run
-      status = `passenger-status --show=xml`
-      return if status.empty?
+    # Good job Passenger 4.0.10. Return non xml in your xml output.
+    status = status.split("\n")[3..-1].join("\n") unless status.start_with?('<?xml')
 
-      statsd = Datadog::Statsd.new
+    statsd = Datadog::Statsd.new
+    parsed = Nokogiri::XML(status)
 
-      statsd.batch do |s|
-        # Good job Passenger 4.0.10. Return non xml in your xml output.
-        status = status.split("\n")[3..-1].join("\n") unless status.start_with?('<?xml')
-        parsed = Nokogiri::XML(status)
+    statsd.batch do |s|
+      Parsers::Root.new(s, parsed.xpath('//info')).run
 
-        pool_used = parsed.xpath('//process_count').text
-        s.gauge('passenger.pool.used', pool_used)
+      parsed.xpath('//supergroups/supergroup').each do |supergroup|
+        prefix = normalize_prefix(supergroup.xpath('name').text)
+        Parsers::Group.new(s, supergroup.xpath('group'), prefix: prefix).run
 
-        pool_max = parsed.xpath('//max').text
-        s.gauge('passenger.pool.max', pool_max)
-
-        request_queue = parsed.xpath('//supergroups/supergroup/group/get_wait_list_size').text
-        s.gauge('passenger.request_queue', request_queue)
-
-        parsed.xpath('//supergroups/supergroup/group').each do |group|
-          GROUP_STATS.each do |stat|
-            value = group.xpath(stat).text
-            next if value.empty?
-            s.gauge("passenger.#{stat}", value)
-          end
-        end
-
-        parsed.xpath('//supergroups/supergroup/group/processes/process').each_with_index do |process, index|
-          PROCESS_STATS.each do |stat|
-            value = process.xpath(stat).text
-            next if value.empty?
-            s.gauge("passenger.#{stat}", value, tags: ["passenger-process:#{index}"])
-          end
+        supergroup.xpath('group/processes/process').each_with_index do |process, index|
+          Parsers::Process.new(s, process, prefix: prefix, tags: ["passenger-process:#{index}"]).run
         end
       end
     end
+  end
+
+  private
+
+  def normalize_prefix(prefix)
+    prefix.gsub(/(-|\s)/, "_").gsub(/(\W|\d)/i, "")
   end
 end

--- a/spec/fixtures/passenger_5_status.xml
+++ b/spec/fixtures/passenger_5_status.xml
@@ -5,7 +5,7 @@
    <process_count>2</process_count>
    <max>5</max>
    <capacity_used>2</capacity_used>
-   <get_wait_list_size>0</get_wait_list_size>
+   <get_wait_list_size>999</get_wait_list_size>
    <supergroups>
       <supergroup>
          <name>/passenger_datadog (development)</name>
@@ -23,7 +23,7 @@
             <disabling_process_count>0</disabling_process_count>
             <disabled_process_count>0</disabled_process_count>
             <capacity_used>2</capacity_used>
-            <get_wait_list_size>0</get_wait_list_size>
+            <get_wait_list_size>111</get_wait_list_size>
             <disable_wait_list_size>0</disable_wait_list_size>
             <processes_being_spawned>0</processes_being_spawned>
             <life_status>ALIVE</life_status>

--- a/spec/fixtures/passenger_5_status_multiple_supergroups.xml
+++ b/spec/fixtures/passenger_5_status_multiple_supergroups.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="iso8859-1"?>
+<info version="3">
+   <passenger_version>5.0.20</passenger_version>
+   <group_count>1</group_count>
+   <process_count>2</process_count>
+   <max>5</max>
+   <capacity_used>2</capacity_used>
+   <get_wait_list_size>999</get_wait_list_size>
+   <supergroups>
+      <supergroup>
+         <name>/passenger_datadog (development)</name>
+         <state>READY</state>
+         <get_wait_list_size>0</get_wait_list_size>
+         <capacity_used>2</capacity_used>
+         <group default="true">
+            <name>/passenger_datadog (development)</name>
+            <component_name>/passenger_datadog (development)</component_name>
+            <app_root>/passenger_datadog</app_root>
+            <app_type>rack</app_type>
+            <environment>development</environment>
+            <uuid>hVLZWbyGdHplIJ7S1Bd5</uuid>
+            <enabled_process_count>2</enabled_process_count>
+            <disabling_process_count>0</disabling_process_count>
+            <disabled_process_count>0</disabled_process_count>
+            <capacity_used>2</capacity_used>
+            <get_wait_list_size>111</get_wait_list_size>
+            <disable_wait_list_size>0</disable_wait_list_size>
+            <processes_being_spawned>0</processes_being_spawned>
+            <life_status>ALIVE</life_status>
+            <user>user</user>
+            <uid>500</uid>
+            <group>group</group>
+            <gid>1000</gid>
+            <options>
+               <app_root>/passenger_datadog</app_root>
+               <app_group_name>/passenger_datadog (development)</app_group_name>
+               <app_type>rack</app_type>
+               <start_command>/usr/bin/ruby rack-loader.rb</start_command>
+               <startup_file>/passenger_datadog/config.ru</startup_file>
+               <process_title>Passenger RubyApp</process_title>
+               <log_level>3</log_level>
+               <start_timeout>90000</start_timeout>
+               <environment>development</environment>
+               <base_uri>/</base_uri>
+               <spawn_method>smart</spawn_method>
+               <default_user>nobody</default_user>
+               <default_group>nobody</default_group>
+               <integration_mode>apache</integration_mode>
+               <ruby>/usr/bin/ruby</ruby>
+               <python>python</python>
+               <nodejs>node</nodejs>
+               <ust_router_address>unix:/tmp/passenger.JEe5Fw6/agents.s/ust_router</ust_router_address>
+               <ust_router_username>logging</ust_router_username>
+               <ust_router_password>password</ust_router_password>
+               <debugger>false</debugger>
+               <analytics>false</analytics>
+               <api_key>api_key</api_key>
+               <min_processes>1</min_processes>
+               <max_processes>0</max_processes>
+               <max_preloader_idle_time>300</max_preloader_idle_time>
+               <max_out_of_band_work_instances>1</max_out_of_band_work_instances>
+            </options>
+            <processes>
+               <process>
+                  <pid>30834</pid>
+                  <sticky_session_id>376651144</sticky_session_id>
+                  <gupid>16f8e47-qENzxOi9bQ</gupid>
+                  <concurrency>1</concurrency>
+                  <sessions>0</sessions>
+                  <busyness>0</busyness>
+                  <processed>2</processed>
+                  <spawner_creation_time>1445288098362036</spawner_creation_time>
+                  <spawn_start_time>1445288105478892</spawn_start_time>
+                  <spawn_end_time>1445288105642056</spawn_end_time>
+                  <last_used>1445288133121316</last_used>
+                  <last_used_desc>1h 2m 46s ago</last_used_desc>
+                  <uptime>1h 3m 14s</uptime>
+                  <life_status>ALIVE</life_status>
+                  <enabled>ENABLED</enabled>
+                  <has_metrics>true</has_metrics>
+                  <cpu>0</cpu>
+                  <rss>409596</rss>
+                  <pss>267231</pss>
+                  <private_dirty>126456</private_dirty>
+                  <swap>0</swap>
+                  <real_memory>126456</real_memory>
+                  <vmsize>812632</vmsize>
+                  <process_group_id>30623</process_group_id>
+                  <command>Passenger RubyApp: /passenger_datadog (development)</command>
+               </process>
+               <process>
+                  <pid>30824</pid>
+                  <sticky_session_id>1266337485</sticky_session_id>
+                  <gupid>16f8e47-E7R4UZn1G0</gupid>
+                  <concurrency>1</concurrency>
+                  <sessions>0</sessions>
+                  <busyness>0</busyness>
+                  <processed>3</processed>
+                  <spawner_creation_time>1445288098362036</spawner_creation_time>
+                  <spawn_start_time>1445288104647686</spawn_start_time>
+                  <spawn_end_time>1445288104817834</spawn_end_time>
+                  <last_used>1445288133728356</last_used>
+                  <last_used_desc>1h 2m 46s ago</last_used_desc>
+                  <uptime>1h 3m 15s</uptime>
+                  <life_status>ALIVE</life_status>
+                  <enabled>ENABLED</enabled>
+                  <has_metrics>true</has_metrics>
+                  <cpu>0</cpu>
+                  <rss>407972</rss>
+                  <pss>265607</pss>
+                  <private_dirty>124832</private_dirty>
+                  <swap>0</swap>
+                  <real_memory>124832</real_memory>
+                  <vmsize>812536</vmsize>
+                  <process_group_id>30623</process_group_id>
+                  <command>Passenger RubyApp: /passenger_datadog (development)</command>
+               </process>
+            </processes>
+         </group>
+      </supergroup>
+      <supergroup>
+         <name>/passenger_datadog (production)</name>
+         <state>READY</state>
+         <get_wait_list_size>0</get_wait_list_size>
+         <capacity_used>3</capacity_used>
+         <group default="true">
+            <name>/passenger_datadog (production)</name>
+            <component_name>/passenger_datadog (production)</component_name>
+            <app_root>/passenger_datadog</app_root>
+            <app_type>rack</app_type>
+            <environment>development</environment>
+            <uuid>hVLZWbyGdHplIJ7S1Bd5</uuid>
+            <enabled_process_count>2</enabled_process_count>
+            <disabling_process_count>0</disabling_process_count>
+            <disabled_process_count>0</disabled_process_count>
+            <capacity_used>2</capacity_used>
+            <get_wait_list_size>111</get_wait_list_size>
+            <disable_wait_list_size>0</disable_wait_list_size>
+            <processes_being_spawned>0</processes_being_spawned>
+            <life_status>ALIVE</life_status>
+            <user>user</user>
+            <uid>500</uid>
+            <group>group</group>
+            <gid>1000</gid>
+            <options>
+               <app_root>/passenger_datadog</app_root>
+               <app_group_name>/passenger_datadog (production)</app_group_name>
+               <app_type>rack</app_type>
+               <start_command>/usr/bin/ruby rack-loader.rb</start_command>
+               <startup_file>/passenger_datadog/config.ru</startup_file>
+               <process_title>Passenger RubyApp</process_title>
+               <log_level>3</log_level>
+               <start_timeout>90000</start_timeout>
+               <environment>development</environment>
+               <base_uri>/</base_uri>
+               <spawn_method>smart</spawn_method>
+               <default_user>nobody</default_user>
+               <default_group>nobody</default_group>
+               <integration_mode>apache</integration_mode>
+               <ruby>/usr/bin/ruby</ruby>
+               <python>python</python>
+               <nodejs>node</nodejs>
+               <ust_router_address>unix:/tmp/passenger.JEe5Fw6/agents.s/ust_router</ust_router_address>
+               <ust_router_username>logging</ust_router_username>
+               <ust_router_password>password</ust_router_password>
+               <debugger>false</debugger>
+               <analytics>false</analytics>
+               <api_key>api_key</api_key>
+               <min_processes>1</min_processes>
+               <max_processes>0</max_processes>
+               <max_preloader_idle_time>300</max_preloader_idle_time>
+               <max_out_of_band_work_instances>1</max_out_of_band_work_instances>
+            </options>
+            <processes>
+               <process>
+                  <pid>30834</pid>
+                  <sticky_session_id>376651144</sticky_session_id>
+                  <gupid>16f8e47-qENzxOi9bQ</gupid>
+                  <concurrency>1</concurrency>
+                  <sessions>0</sessions>
+                  <busyness>0</busyness>
+                  <processed>2</processed>
+                  <spawner_creation_time>1445288098362036</spawner_creation_time>
+                  <spawn_start_time>1445288105478892</spawn_start_time>
+                  <spawn_end_time>1445288105642056</spawn_end_time>
+                  <last_used>1445288133121316</last_used>
+                  <last_used_desc>1h 2m 46s ago</last_used_desc>
+                  <uptime>1h 3m 14s</uptime>
+                  <life_status>ALIVE</life_status>
+                  <enabled>ENABLED</enabled>
+                  <has_metrics>true</has_metrics>
+                  <cpu>0</cpu>
+                  <rss>409596</rss>
+                  <pss>267231</pss>
+                  <private_dirty>126456</private_dirty>
+                  <swap>0</swap>
+                  <real_memory>126456</real_memory>
+                  <vmsize>812632</vmsize>
+                  <process_group_id>30623</process_group_id>
+                  <command>Passenger RubyApp: /passenger_datadog (production)</command>
+               </process>
+            </processes>
+         </group>
+      </supergroup>
+   </supergroups>
+</info>

--- a/spec/passenger_datadog_spec.rb
+++ b/spec/passenger_datadog_spec.rb
@@ -113,9 +113,11 @@ describe PassengerDatadog do
     let(:passenger_status) do
       [['passenger.pool.used', '2'],
        ['passenger.pool.max', '5'],
-       ['passenger.request_queue', '0'],
+       ['passenger.request_queue', '999'],
 
        ['passenger.passenger_datadog_development.capacity_used', '2'],
+       ['passenger.passenger_datadog_development.get_wait_list_size', '111'],
+       ['passenger.passenger_datadog_development.disable_wait_list_size', '0'],
        ['passenger.passenger_datadog_development.processes_being_spawned', '0'],
        ['passenger.passenger_datadog_development.enabled_process_count', '2'],
        ['passenger.passenger_datadog_development.disabling_process_count', '0'],

--- a/spec/passenger_datadog_spec.rb
+++ b/spec/passenger_datadog_spec.rb
@@ -5,86 +5,88 @@ require 'spec_helper'
 describe PassengerDatadog do
   let(:Statsd) { double(Datadog::Statsd) }
   let(:statsd) { instance_double(Datadog::Statsd) }
+  subject { described_class.new }
 
   context 'passenger not running' do
     before do
-      allow(described_class).to receive(:`).and_return('')
+      allow(subject).to receive(:`).and_return('')
     end
 
     it 'does not send stats to datadog' do
       expect(Datadog::Statsd).not_to receive(:new)
 
-      described_class.run
+      subject.run
     end
   end
 
   context 'passenger 4' do
     before do
-      allow(described_class).to receive(:`).and_return(File.read('spec/fixtures/passenger_4_status.xml'))
+      allow(subject).to receive(:`).and_return(File.read('spec/fixtures/passenger_4_status.xml'))
     end
 
     let(:passenger_status) do
       [['passenger.pool.used', '5'],
        ['passenger.pool.max', '20'],
        ['passenger.request_queue', '0'],
-       ['passenger.enabled_process_count', '5'],
-       ['passenger.disabling_process_count', '0'],
-       ['passenger.disabled_process_count', '0'],
 
-       ['passenger.processed', '149', { tags: ['passenger-process:0'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:0'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.rss', '554312', { tags: ['passenger-process:0'] }],
-       ['passenger.private_dirty', '548660', { tags: ['passenger-process:0'] }],
-       ['passenger.pss', '549560', { tags: ['passenger-process:0'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.real_memory', '548660', { tags: ['passenger-process:0'] }],
-       ['passenger.vmsize', '952668', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.enabled_process_count', '5'],
+       ['passenger.passenger_datadog.disabling_process_count', '0'],
+       ['passenger.passenger_datadog.disabled_process_count', '0'],
 
-       ['passenger.processed', '273', { tags: ['passenger-process:1'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:1'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.rss', '547088', { tags: ['passenger-process:1'] }],
-       ['passenger.private_dirty', '541420', { tags: ['passenger-process:1'] }],
-       ['passenger.pss', '542326', { tags: ['passenger-process:1'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.real_memory', '541420', { tags: ['passenger-process:1'] }],
-       ['passenger.vmsize', '963948', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.processed', '149', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.rss', '554312', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.private_dirty', '548660', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.pss', '549560', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.real_memory', '548660', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog.vmsize', '952668', { tags: ['passenger-process:0'] }],
 
-       ['passenger.processed', '139', { tags: ['passenger-process:2'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:2'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.rss', '533704', { tags: ['passenger-process:2'] }],
-       ['passenger.private_dirty', '258196', { tags: ['passenger-process:2'] }],
-       ['passenger.pss', '394044', { tags: ['passenger-process:2'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.real_memory', '258196', { tags: ['passenger-process:2'] }],
-       ['passenger.vmsize', '887132', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.processed', '273', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.rss', '547088', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.private_dirty', '541420', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.pss', '542326', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.real_memory', '541420', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog.vmsize', '963948', { tags: ['passenger-process:1'] }],
 
-       ['passenger.processed', '135', { tags: ['passenger-process:3'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:3'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:3'] }],
-       ['passenger.cpu', '1', { tags: ['passenger-process:3'] }],
-       ['passenger.rss', '559972', { tags: ['passenger-process:3'] }],
-       ['passenger.private_dirty', '284396', { tags: ['passenger-process:3'] }],
-       ['passenger.pss', '420259', { tags: ['passenger-process:3'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:3'] }],
-       ['passenger.real_memory', '284396', { tags: ['passenger-process:3'] }],
-       ['passenger.vmsize', '915564', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.processed', '139', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.rss', '533704', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.private_dirty', '258196', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.pss', '394044', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.real_memory', '258196', { tags: ['passenger-process:2'] }],
+       ['passenger.passenger_datadog.vmsize', '887132', { tags: ['passenger-process:2'] }],
 
-       ['passenger.processed', '236', { tags: ['passenger-process:4'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:4'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.rss', '548696', { tags: ['passenger-process:4'] }],
-       ['passenger.private_dirty', '543068', { tags: ['passenger-process:4'] }],
-       ['passenger.pss', '543957', { tags: ['passenger-process:4'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.real_memory', '543068', { tags: ['passenger-process:4'] }],
-       ['passenger.vmsize', '964668', { tags: ['passenger-process:4'] }]]
+       ['passenger.passenger_datadog.processed', '135', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.cpu', '1', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.rss', '559972', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.private_dirty', '284396', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.pss', '420259', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.real_memory', '284396', { tags: ['passenger-process:3'] }],
+       ['passenger.passenger_datadog.vmsize', '915564', { tags: ['passenger-process:3'] }],
+
+       ['passenger.passenger_datadog.processed', '236', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.rss', '548696', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.private_dirty', '543068', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.pss', '543957', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.real_memory', '543068', { tags: ['passenger-process:4'] }],
+       ['passenger.passenger_datadog.vmsize', '964668', { tags: ['passenger-process:4'] }]]
     end
 
     it 'sends stats to datadog' do
@@ -99,48 +101,49 @@ describe PassengerDatadog do
         expect(statsd).to receive(:gauge).with(key, *value)
       end
 
-      described_class.run
+      subject.run
     end
   end
 
   context 'passenger 5' do
     before do
-      allow(described_class).to receive(:`).and_return(File.read('spec/fixtures/passenger_5_status.xml'))
+      allow(subject).to receive(:`).and_return(File.read('spec/fixtures/passenger_5_status.xml'))
     end
 
     let(:passenger_status) do
       [['passenger.pool.used', '2'],
        ['passenger.pool.max', '5'],
        ['passenger.request_queue', '0'],
-       ['passenger.capacity_used', '2'],
-       ['passenger.processes_being_spawned', '0'],
-       ['passenger.enabled_process_count', '2'],
-       ['passenger.disabling_process_count', '0'],
-       ['passenger.disabled_process_count', '0'],
 
-       ['passenger.processed', '2', { tags: ['passenger-process:0'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.busyness', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:0'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.rss', '409596', { tags: ['passenger-process:0'] }],
-       ['passenger.private_dirty', '126456', { tags: ['passenger-process:0'] }],
-       ['passenger.pss', '267231', { tags: ['passenger-process:0'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.real_memory', '126456', { tags: ['passenger-process:0'] }],
-       ['passenger.vmsize', '812632', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.capacity_used', '2'],
+       ['passenger.passenger_datadog_development.processes_being_spawned', '0'],
+       ['passenger.passenger_datadog_development.enabled_process_count', '2'],
+       ['passenger.passenger_datadog_development.disabling_process_count', '0'],
+       ['passenger.passenger_datadog_development.disabled_process_count', '0'],
 
-       ['passenger.processed', '3', { tags: ['passenger-process:1'] }],
-       ['passenger.sessions', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.busyness', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.concurrency', '1', { tags: ['passenger-process:1'] }],
-       ['passenger.cpu', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.rss', '407972', { tags: ['passenger-process:1'] }],
-       ['passenger.private_dirty', '124832', { tags: ['passenger-process:1'] }],
-       ['passenger.pss', '265607', { tags: ['passenger-process:1'] }],
-       ['passenger.swap', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.real_memory', '124832', { tags: ['passenger-process:1'] }],
-       ['passenger.vmsize', '812536', { tags: ['passenger-process:1'] }]]
+       ['passenger.passenger_datadog_development.processed', '2', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.sessions', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.busyness', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.concurrency', '1', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.cpu', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.rss', '409596', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.private_dirty', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.pss', '267231', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.swap', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.real_memory', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_development.vmsize', '812632', { tags: ['passenger-process:0'] }],
+
+       ['passenger.passenger_datadog_development.processed', '3', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.sessions', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.busyness', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.concurrency', '1', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.cpu', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.rss', '407972', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.private_dirty', '124832', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.pss', '265607', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.swap', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.real_memory', '124832', { tags: ['passenger-process:1'] }],
+       ['passenger.passenger_datadog_development.vmsize', '812536', { tags: ['passenger-process:1'] }]]
     end
 
     it 'sends stats to datadog' do
@@ -151,7 +154,7 @@ describe PassengerDatadog do
         expect(statsd).to receive(:gauge).with(key, *value)
       end
 
-      described_class.run
+      subject.run
     end
   end
 end

--- a/spec/passenger_datadog_spec.rb
+++ b/spec/passenger_datadog_spec.rb
@@ -29,64 +29,64 @@ describe PassengerDatadog do
        ['passenger.pool.max', '20'],
        ['passenger.request_queue', '0'],
 
-       ['passenger.passenger_datadog.enabled_process_count', '5'],
-       ['passenger.passenger_datadog.disabling_process_count', '0'],
-       ['passenger.passenger_datadog.disabled_process_count', '0'],
+       ['passenger.enabled_process_count', '5'],
+       ['passenger.disabling_process_count', '0'],
+       ['passenger.disabled_process_count', '0'],
 
-       ['passenger.passenger_datadog.processed', '149', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.rss', '554312', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.private_dirty', '548660', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.pss', '549560', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.real_memory', '548660', { tags: ['passenger-process:0'] }],
-       ['passenger.passenger_datadog.vmsize', '952668', { tags: ['passenger-process:0'] }],
+       ['passenger.processed', '149', { tags: ['passenger-process:0'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:0'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.rss', '554312', { tags: ['passenger-process:0'] }],
+       ['passenger.private_dirty', '548660', { tags: ['passenger-process:0'] }],
+       ['passenger.pss', '549560', { tags: ['passenger-process:0'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.real_memory', '548660', { tags: ['passenger-process:0'] }],
+       ['passenger.vmsize', '952668', { tags: ['passenger-process:0'] }],
 
-       ['passenger.passenger_datadog.processed', '273', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.rss', '547088', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.private_dirty', '541420', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.pss', '542326', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.real_memory', '541420', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog.vmsize', '963948', { tags: ['passenger-process:1'] }],
+       ['passenger.processed', '273', { tags: ['passenger-process:1'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:1'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.rss', '547088', { tags: ['passenger-process:1'] }],
+       ['passenger.private_dirty', '541420', { tags: ['passenger-process:1'] }],
+       ['passenger.pss', '542326', { tags: ['passenger-process:1'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.real_memory', '541420', { tags: ['passenger-process:1'] }],
+       ['passenger.vmsize', '963948', { tags: ['passenger-process:1'] }],
 
-       ['passenger.passenger_datadog.processed', '139', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.rss', '533704', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.private_dirty', '258196', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.pss', '394044', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.real_memory', '258196', { tags: ['passenger-process:2'] }],
-       ['passenger.passenger_datadog.vmsize', '887132', { tags: ['passenger-process:2'] }],
+       ['passenger.processed', '139', { tags: ['passenger-process:2'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:2'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.rss', '533704', { tags: ['passenger-process:2'] }],
+       ['passenger.private_dirty', '258196', { tags: ['passenger-process:2'] }],
+       ['passenger.pss', '394044', { tags: ['passenger-process:2'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:2'] }],
+       ['passenger.real_memory', '258196', { tags: ['passenger-process:2'] }],
+       ['passenger.vmsize', '887132', { tags: ['passenger-process:2'] }],
 
-       ['passenger.passenger_datadog.processed', '135', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.cpu', '1', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.rss', '559972', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.private_dirty', '284396', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.pss', '420259', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.real_memory', '284396', { tags: ['passenger-process:3'] }],
-       ['passenger.passenger_datadog.vmsize', '915564', { tags: ['passenger-process:3'] }],
+       ['passenger.processed', '135', { tags: ['passenger-process:3'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:3'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:3'] }],
+       ['passenger.cpu', '1', { tags: ['passenger-process:3'] }],
+       ['passenger.rss', '559972', { tags: ['passenger-process:3'] }],
+       ['passenger.private_dirty', '284396', { tags: ['passenger-process:3'] }],
+       ['passenger.pss', '420259', { tags: ['passenger-process:3'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:3'] }],
+       ['passenger.real_memory', '284396', { tags: ['passenger-process:3'] }],
+       ['passenger.vmsize', '915564', { tags: ['passenger-process:3'] }],
 
-       ['passenger.passenger_datadog.processed', '236', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.sessions', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.concurrency', '1', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.cpu', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.rss', '548696', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.private_dirty', '543068', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.pss', '543957', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.swap', '0', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.real_memory', '543068', { tags: ['passenger-process:4'] }],
-       ['passenger.passenger_datadog.vmsize', '964668', { tags: ['passenger-process:4'] }]]
+       ['passenger.processed', '236', { tags: ['passenger-process:4'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:4'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.rss', '548696', { tags: ['passenger-process:4'] }],
+       ['passenger.private_dirty', '543068', { tags: ['passenger-process:4'] }],
+       ['passenger.pss', '543957', { tags: ['passenger-process:4'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:4'] }],
+       ['passenger.real_memory', '543068', { tags: ['passenger-process:4'] }],
+       ['passenger.vmsize', '964668', { tags: ['passenger-process:4'] }]]
     end
 
     it 'sends stats to datadog' do
@@ -108,6 +108,61 @@ describe PassengerDatadog do
   context 'passenger 5' do
     before do
       allow(subject).to receive(:`).and_return(File.read('spec/fixtures/passenger_5_status.xml'))
+    end
+
+    let(:passenger_status) do
+      [['passenger.pool.used', '2'],
+       ['passenger.pool.max', '5'],
+       ['passenger.request_queue', '999'],
+
+       ['passenger.capacity_used', '2'],
+       ['passenger.get_wait_list_size', '111'],
+       ['passenger.disable_wait_list_size', '0'],
+       ['passenger.processes_being_spawned', '0'],
+       ['passenger.enabled_process_count', '2'],
+       ['passenger.disabling_process_count', '0'],
+       ['passenger.disabled_process_count', '0'],
+
+       ['passenger.processed', '2', { tags: ['passenger-process:0'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.busyness', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:0'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.rss', '409596', { tags: ['passenger-process:0'] }],
+       ['passenger.private_dirty', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.pss', '267231', { tags: ['passenger-process:0'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.real_memory', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.vmsize', '812632', { tags: ['passenger-process:0'] }],
+
+       ['passenger.processed', '3', { tags: ['passenger-process:1'] }],
+       ['passenger.sessions', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.busyness', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.concurrency', '1', { tags: ['passenger-process:1'] }],
+       ['passenger.cpu', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.rss', '407972', { tags: ['passenger-process:1'] }],
+       ['passenger.private_dirty', '124832', { tags: ['passenger-process:1'] }],
+       ['passenger.pss', '265607', { tags: ['passenger-process:1'] }],
+       ['passenger.swap', '0', { tags: ['passenger-process:1'] }],
+       ['passenger.real_memory', '124832', { tags: ['passenger-process:1'] }],
+       ['passenger.vmsize', '812536', { tags: ['passenger-process:1'] }]]
+    end
+
+    it 'sends stats to datadog' do
+      allow(Datadog::Statsd).to receive(:new).and_return(statsd)
+      allow(statsd).to receive(:batch).and_yield(statsd)
+
+      passenger_status.each do |key, *value|
+        expect(statsd).to receive(:gauge).with(key, *value)
+      end
+
+      subject.run
+    end
+  end
+
+  context 'passenger 5 with multiple supergroups' do
+    before do
+      allow(subject).to receive(:`).and_return(File.read('spec/fixtures/passenger_5_status_multiple_supergroups.xml'))
     end
 
     let(:passenger_status) do
@@ -145,7 +200,27 @@ describe PassengerDatadog do
        ['passenger.passenger_datadog_development.pss', '265607', { tags: ['passenger-process:1'] }],
        ['passenger.passenger_datadog_development.swap', '0', { tags: ['passenger-process:1'] }],
        ['passenger.passenger_datadog_development.real_memory', '124832', { tags: ['passenger-process:1'] }],
-       ['passenger.passenger_datadog_development.vmsize', '812536', { tags: ['passenger-process:1'] }]]
+       ['passenger.passenger_datadog_development.vmsize', '812536', { tags: ['passenger-process:1'] }],
+
+       ['passenger.passenger_datadog_production.capacity_used', '2'],
+       ['passenger.passenger_datadog_production.get_wait_list_size', '111'],
+       ['passenger.passenger_datadog_production.disable_wait_list_size', '0'],
+       ['passenger.passenger_datadog_production.processes_being_spawned', '0'],
+       ['passenger.passenger_datadog_production.enabled_process_count', '2'],
+       ['passenger.passenger_datadog_production.disabling_process_count', '0'],
+       ['passenger.passenger_datadog_production.disabled_process_count', '0'],
+
+       ['passenger.passenger_datadog_production.processed', '2', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.sessions', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.busyness', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.concurrency', '1', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.cpu', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.rss', '409596', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.private_dirty', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.pss', '267231', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.swap', '0', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.real_memory', '126456', { tags: ['passenger-process:0'] }],
+       ['passenger.passenger_datadog_production.vmsize', '812632', { tags: ['passenger-process:0'] }]]
     end
 
     it 'sends stats to datadog' do


### PR DESCRIPTION
This PR aims to achieve multiple things:

- Improve support for deployments with multiple supergroups. In that case each supergroup is tracked separately
- Refactor parsing into multiple classes. This improves code maintainability
- Add missing `group` properties: `get_wait_list_size` and `disable_wait_list_size`
- Fixes a bug with `passenger.request_queue` value being concatenated out of nested `get_wait_list_size` values